### PR TITLE
Fix inconsistencies in PCij matrix notation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 version.py
+docs/api
+docs/generated
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,29 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+python:
+  version: 3.10
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+        - all

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,22 +5,12 @@
 # Required
 version: 2
 
-# Set the OS, Python version and other tools you might need
-build:
-  os: ubuntu-22.04
-  tools:
-    python: "3.10"
-    # You can also specify other tool versions:
-    # nodejs: "19"
-    # rust: "1.64"
-    # golang: "1.19"
-
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
    configuration: docs/conf.py
 
 python:
-  version: 3.10
+  version: 3.8
   install:
     - method: pip
       path: .

--- a/docs/code_ref.rst
+++ b/docs/code_ref.rst
@@ -1,0 +1,10 @@
+API Reference
+=============
+
+.. automodapi:: overlappy.io
+
+.. automodapi:: overlappy.reproject
+
+.. automodapi:: overlappy.util
+
+.. automodapi:: overlappy.wcs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,6 +34,8 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx_automodapi.automodapi',
     'sphinx_automodapi.smart_resolver',
+    'matplotlib.sphinxext.plot_directive',
+    'sphinx_gallery.gen_gallery',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -54,15 +56,31 @@ master_doc = 'index'
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/',None),
+    'astropy': ('https://docs.astropy.org/en/stable', None),
+    'numpy': ('https://numpy.org/doc/stable/',
+              (None, 'http://data.astropy.org/intersphinx/numpy.inv')),
+    'sunpy': ('https://docs.sunpy.org/en/stable/', None),
+    'ndcube': ('https://docs.sunpy.org/projects/ndcube/en/stable/', None),
+}
 
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'alabaster'
+html_theme = 'sphinx_book_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 # html_static_path = ['_static']
+
+# Sphinx Gallery
+
+sphinx_gallery_conf = {
+    'examples_dirs': '../examples',   # path to your example scripts
+    'gallery_dirs': 'generated/gallery',  # path to where to save gallery generated output
+    'filename_pattern': '^((?!skip_).)*$',
+    'matplotlib_animations': True,
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,11 +7,5 @@ This is the documentation for overlappy.
    :maxdepth: 2
    :caption: Contents:
 
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+   code_ref
+   generated/gallery/index

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -1,0 +1,2 @@
+WCS Grid Examples
+=================

--- a/examples/plot_overlappogram_grids.py
+++ b/examples/plot_overlappogram_grids.py
@@ -1,0 +1,93 @@
+"""
+WCS Grid Examples
+=================
+
+A bunch of examples of different kinds of overlappogram WCS that can be created.
+This is mainly a convenient way to visualize how these different WCS behave.
+"""
+import astropy.units as u
+import numpy as np
+import matplotlib.pyplot as plt
+import ndcube
+from sunpy.coordinates import get_earth
+from sunpy.visualization.wcsaxes_compat import wcsaxes_heliographic_overlay
+from overlappy.wcs import overlappogram_fits_wcs, pcij_matrix
+from overlappy.util import strided_array, color_lat_lon_axes
+
+#################################################################################
+# First, set up some of the base parameters for our WCS and the data array
+#
+shape = (50, 50)
+spectral_platescale = 10 * u.Angstrom / u.pix
+spatial_platescale = [150, 150] * u.arcsec / u.pix
+wavelength = np.arange(0, 150, spectral_platescale.value) * spectral_platescale.unit * u.pix
+data = np.zeros(shape)
+data = strided_array(data, wavelength.shape[0])
+observer = get_earth('2020-01-01')
+
+
+def make_grid_plot(alpha, gamma, mu):
+    pcij = pcij_matrix(alpha, gamma, mu)
+    wcs = overlappogram_fits_wcs(shape,
+                                 wavelength,
+                                 (spatial_platescale[0], spatial_platescale[1], spectral_platescale),
+                                 pc_matrix=pcij,
+                                 observer=observer)
+    cube = ndcube.NDCube(data, wcs=wcs)
+    fig = plt.figure(figsize=(5, 5*wavelength.shape[0]))
+    for i in range(wavelength.shape[0]):
+        ax = fig.add_subplot(wavelength.shape[0], 1, i+1, projection=cube[i].wcs)
+        cube[i].plot(axes=ax)
+        ax.set_title(wavelength[i])
+        color_lat_lon_axes(ax)
+        wcsaxes_heliographic_overlay(ax, grid_spacing=20*u.deg, annotate=False)
+    plt.show()
+
+
+# %%
+# Example 1: :math:`\alpha=0,\gamma=0,\mu=0`
+# --------------------------------------------
+#
+make_grid_plot(0*u.deg, 0*u.deg, 0)
+
+# %%
+# Example 2: :math:`\alpha=0,\gamma=0,\mu=1`
+# --------------------------------------------
+#
+make_grid_plot(0*u.deg, 0*u.deg, 1)
+
+# %%
+# Example 3: :math:`\alpha=90,\gamma=0,\mu=1`
+# --------------------------------------------
+#
+make_grid_plot(90*u.deg, 0*u.deg, 1)
+
+# %%
+# Example 4: :math:`\alpha=90,\gamma=0,\mu=3`
+# --------------------------------------------
+#
+make_grid_plot(90*u.deg, 0*u.deg, 3)
+
+# %%
+# Example 5: :math:`\alpha=90,\gamma=45,\mu=1`
+# --------------------------------------------
+#
+make_grid_plot(90*u.deg, 45*u.deg, 1)
+
+# %%
+# Example 6: :math:`\alpha=90,\gamma=45,\mu=-1`
+# ---------------------------------------------
+#
+make_grid_plot(90*u.deg, 45*u.deg, -1)
+
+# %%
+# Example 6: :math:`\alpha=30,\gamma=30,\mu=2`
+# ------------------------------------------
+#
+make_grid_plot(30*u.deg, 30*u.deg, 2)
+
+# %%
+# Example 7: :math:`\alpha=0,\gamma=-90,\mu=1`
+# ------------------------------------------
+#
+make_grid_plot(0*u.deg, -90*u.deg, 1)

--- a/overlappy/io.py
+++ b/overlappy/io.py
@@ -7,6 +7,11 @@ import ndcube
 
 from .util import strided_array
 
+__all__ = [
+    "write_overlappogram",
+    "read_overlappogram",
+]
+
 
 def write_overlappogram(cube, filename):
     header = cube.wcs.to_header()

--- a/overlappy/reproject.py
+++ b/overlappy/reproject.py
@@ -9,6 +9,10 @@ import reproject
 from .wcs import pcij_matrix, overlappogram_fits_wcs
 from .util import strided_array
 
+__all__ = [
+    "reproject_to_overlappogram",
+]
+
 
 def reproject_to_overlappogram(cube,
                                detector_shape,
@@ -17,7 +21,6 @@ def reproject_to_overlappogram(cube,
                                scale=None,
                                roll_angle=0*u.deg,
                                dispersion_angle=0*u.deg,
-                               dispersion_axis=0,
                                order=1,
                                observer=None,
                                sum_over_lambda=True,
@@ -63,7 +66,7 @@ def reproject_to_overlappogram(cube,
     """
     wavelength = cube.axis_world_coords(0)[0].to('angstrom')
     pc_matrix = pcij_matrix(roll_angle, dispersion_angle,
-                            order=order, dispersion_axis=dispersion_axis)
+                            order=order)
     if scale is None:
         scale = [u.Quantity(cd, f'{cu} / pix') for cd, cu in
                  zip(cube.wcs.wcs.cdelt, cube.wcs.wcs.cunit)]

--- a/overlappy/tests/test_pcij.py
+++ b/overlappy/tests/test_pcij.py
@@ -1,0 +1,22 @@
+"""
+Tests for PCij matrix for different combinations of roll and grating
+"""
+import pytest
+import numpy as np
+import astropy.units as u
+
+from overlappy.wcs import pcij_matrix
+
+
+@pytest.mark.parametrize('roll_angle,grating_angle,order,expected_matrix', [
+    (0*u.deg, 0*u.deg, 0, np.eye(3)),
+    (0*u.deg, 0*u.deg, 1, [[1, 0, -1], [0, 1, 0], [0, 0, 1]]),
+    (0*u.deg, 0*u.deg, 2, [[1, 0, -2], [0, 1, 0], [0, 0, 1]]),
+    (0*u.deg, 0*u.deg, -1, [[1, 0, 1], [0, 1, 0], [0, 0, 1]]),
+    (90*u.deg, 0*u.deg, 0, [[0, -1, 0], [1, 0, 0], [0, 0, 1]]),
+])
+def test_pcij_simple(roll_angle, grating_angle, order, expected_matrix):
+    pcij = pcij_matrix(roll_angle=roll_angle,
+                       dispersion_angle=grating_angle,
+                       order=order)
+    assert np.allclose(pcij, np.array(expected_matrix))

--- a/overlappy/tests/test_pcij.py
+++ b/overlappy/tests/test_pcij.py
@@ -14,6 +14,11 @@ from overlappy.wcs import pcij_matrix
     (0*u.deg, 0*u.deg, 2, [[1, 0, -2], [0, 1, 0], [0, 0, 1]]),
     (0*u.deg, 0*u.deg, -1, [[1, 0, 1], [0, 1, 0], [0, 0, 1]]),
     (90*u.deg, 0*u.deg, 0, [[0, -1, 0], [1, 0, 0], [0, 0, 1]]),
+    (90*u.deg, 0*u.deg, 1, [[0, -1, 0], [1, 0, -1], [0, 0, 1]]),
+    (0*u.deg, 45*u.deg, 0, np.eye(3)),
+    (0*u.deg, 90*u.deg, 1, [[1, 0, 0], [0, 1, 1], [0, 0, 1]]),
+    (30*u.deg, 30*u.deg, 1, [[np.sqrt(3)/2, -1/2, -1], [1/2, np.sqrt(3)/2, 0], [0, 0, 1]]),
+    (60*u.deg, 30*u.deg, 3, [[1/2, -np.sqrt(3)/2, -3*np.sqrt(3)/2], [np.sqrt(3)/2, 1/2, -3/2], [0, 0, 1]])
 ])
 def test_pcij_simple(roll_angle, grating_angle, order, expected_matrix):
     pcij = pcij_matrix(roll_angle=roll_angle,

--- a/overlappy/util.py
+++ b/overlappy/util.py
@@ -5,6 +5,14 @@ import numpy as np
 import astropy.units as u
 import astropy.constants
 
+__all__ = [
+    "draw_hgs_grid",
+    "color_lat_lon_axes",
+    "hgs_observer_to_keys",
+    "pcij_to_keys",
+    "strided_array",
+]
+
 
 def draw_hgs_grid(ax, observer):
     from sunpy.visualization.wcsaxes_compat import wcsaxes_heliographic_overlay

--- a/overlappy/wcs.py
+++ b/overlappy/wcs.py
@@ -7,61 +7,92 @@ import astropy.wcs
 
 from .util import pcij_to_keys, hgs_observer_to_keys
 
+__all__ = [
+    "rotation_matrix",
+    "dispersion_matrix",
+    "pcij_matrix",
+    "overlappogram_fits_wcs",
+]
+
 
 @u.quantity_input
 def rotation_matrix(angle: u.deg):
+    r"""
+    3D rotation matrix that applies a rotation in only the first two dimensions.
+    This has the form:
+
+    .. math::
+
+        R(\theta) = \begin{bmatrix}
+                        \cos{\theta} & -\sin{\theta} & 0 \\
+                        \sin{\theta} & \cos{\theta} & 0 \\
+                        0 & 0 & 1
+                    \end{bmatrix}
+    """
     return np.array([
-        [np.cos(angle), np.sin(angle), 0],
-        [-np.sin(angle), np.cos(angle), 0],
+        [np.cos(angle), -np.sin(angle), 0],
+        [np.sin(angle), np.cos(angle), 0],
         [0, 0, 1]
     ])
 
 
 @u.quantity_input
-def dispersion_matrix(order, dispersion_axis=0):
+def dispersion_matrix(order):
+    r"""
+    This operation represents a skew according to the spectral order
+    along the first pixel axis. This matrix has the form:
+
+    .. math::
+
+        D(\mu) = \begin{bmatrix}
+                    1 & 0 & -\mu \\
+                    0 & 1 & 0 \\
+                    0 & 0 & 1
+                 \end{bmatrix}
+    """
     dispersion_array = np.eye(3)
-    dispersion_array[dispersion_axis, 2] = -order
+    dispersion_array[0, 2] = -order
     return dispersion_array
 
 
 @u.quantity_input
 def pcij_matrix(roll_angle: u.deg,
                 dispersion_angle: u.deg,
-                order=1,
-                dispersion_axis=0,
-                align_p2_wave=False):
-    """
+                order=1):
+    r"""
+    Create a ``PC_ij`` matrix for an slitless spectrogram.
+
+    Calculate a ``PC_ij`` matrix for a slitless spectrogram with a grating angle
+    of :math:`\gamma`, a satellite roll angle of :math:`\alpha`, and a spectral
+    dispersion of :math:`\mu`. This has the form,
+
+    .. math::
+
+        P(\alpha, \gamma, \mu) &= R(\alpha - \gamma)D(\mu)R(\gamma) \\
+                               &= \begin{bmatrix}
+                                    \cos{\alpha} & -\sin{\alpha} & \mu\cos{\alpha - \gamma}\\
+                                    \sin{\alpha} & \cos{\alpha} & \mu\sin{\alpha - \gamma}\\
+                                    0 & 0 & 1
+                                   \end{bmatrix}
+
     Parameters
     ----------
-    roll_angle: 
+    roll_angle : `~astropy.units.Quantity`
         Angle between the second pixel axis and the y-like
-        world axis.
-    dispersion_angle:
-        Angle between the wavelength (dispersion) axis and the second pixel axis.
-    order:
-        Order of the dispersion. Default is 1.
+        world axis. This is the roll angle of the satellite.
+    dispersion_angle : `~astropy.units.Quantity`
+        Angle between the direction of spectral dispersion and the x-like pixel axis.
+        This is the angle between the dispersive element and the detector.
+    order : `int`, optional
+        Order of the spectral dispersion. Default is 1.
     """
     R_2 = rotation_matrix(roll_angle - dispersion_angle)
-    D = dispersion_matrix(order, dispersion_axis=dispersion_axis)
-    if align_p2_wave:
-        # This aligns the dispersion axis with the wavelength axis
-        # and decorrelates wavelength with the the third "fake"
-        # pixel axis. This means that wavelength *does not* vary
-        # as you increment that third axis.
-        # This is not strictly correct as the world grid at each p3
-        # should only correspond to a particular wavelength, not
-        # all of them.
-        # This may be useful when plotting two slices of the overlappogram
-        # and displaying a wavelength axis. However, this will not work
-        # when performing reprojections. If you want this capability, you
-        # should apply this PCij to your WCS after the fact.
-        D[2, dispersion_axis] = 1
-        D[2, 2] = 0
+    D = dispersion_matrix(order)
     R_1 = rotation_matrix(dispersion_angle)
     # The operation here is (from R to L):
-    # -- align dispersion axis with p2 pixel axis
-    # -- disperse in spectral order along p2 axis
-    # -- apply roll angle rotation
+    # -- align dispersion axis with p1 pixel axis
+    # -- disperse in spectral order along p1 axis
+    # -- apply effective roll angle rotation
     return R_2 @ D @ R_1
 
 

--- a/overlappy/wcs.py
+++ b/overlappy/wcs.py
@@ -70,8 +70,8 @@ def pcij_matrix(roll_angle: u.deg,
 
         P(\alpha, \gamma, \mu) &= R(\alpha - \gamma)D(\mu)R(\gamma) \\
                                &= \begin{bmatrix}
-                                    \cos{\alpha} & -\sin{\alpha} & \mu\cos{\alpha - \gamma}\\
-                                    \sin{\alpha} & \cos{\alpha} & \mu\sin{\alpha - \gamma}\\
+                                    \cos{\alpha} & -\sin{\alpha} & -\mu\cos{\alpha - \gamma}\\
+                                    \sin{\alpha} & \cos{\alpha} & -\mu\sin{\alpha - \gamma}\\
                                     0 & 0 & 1
                                    \end{bmatrix}
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ long_description = file: README.rst
 zip_safe = False
 packages = find:
 include_package_data = True
-python_requires = >=3.9
+python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires = 
   ndcube

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,9 +12,12 @@ long_description = file: README.rst
 zip_safe = False
 packages = find:
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.9
 setup_requires = setuptools_scm
 install_requires = 
+  ndcube
+  sunpy[map]
+  reproject
 
 
 [options.entry_points]
@@ -30,6 +33,8 @@ test =
     pytest-cov
 docs =
     sphinx
+    sphinx-gallery
+    sphinx-book-theme
     sphinx-automodapi
 
 [tool:pytest]


### PR DESCRIPTION
This fixes some minor inconsistencies in how I was defining the roll and grating angle in the overlappogram PCij. Previously, I had defined the roll angle of the spacecraft and the grating roll to be in the CCW direction. This had the effect of needing to define the rotation matrix in the opposite way it most conventionally defined. This is now fixed by using the conventional notation of the rotation matrix and defining both angles to be CW.

Additionally, this PR also

- Removes the `dispersion_axis` option as this is possible by just setting `gamma=-90`.
- cleans up some doctstrings
- adds an example gallery entry showing all different orientations of the spacecraft roll and grating angle
- adds RTD config

TODO:

- [x] Fix tests
- [ ] Add GH action?