### PR TITLE
Use full shape to generate overlappogram WCS

### DIFF
--- a/examples/plot_overlappogram_grids.py
+++ b/examples/plot_overlappogram_grids.py
@@ -28,8 +28,8 @@ observer = get_earth('2020-01-01')
 
 def make_grid_plot(alpha, gamma, mu):
     pcij = pcij_matrix(alpha, gamma, mu)
-    wcs = overlappogram_fits_wcs(shape,
-                                 wavelength,
+    print('PC_ij = ', pcij)
+    wcs = overlappogram_fits_wcs(wavelength.shape+shape,
                                  (spatial_platescale[0], spatial_platescale[1], spectral_platescale),
                                  pc_matrix=pcij,
                                  observer=observer)

--- a/overlappy/reproject.py
+++ b/overlappy/reproject.py
@@ -71,8 +71,7 @@ def reproject_to_overlappogram(cube,
         scale = [u.Quantity(cd, f'{cu} / pix') for cd, cu in
                  zip(cube.wcs.wcs.cdelt, cube.wcs.wcs.cunit)]
     overlap_wcs = overlappogram_fits_wcs(
-        detector_shape,
-        wavelength,
+        wavelength.shape+detector_shape,
         scale,
         reference_pixel=reference_pixel,
         reference_coord=reference_coord,
@@ -88,6 +87,7 @@ def reproject_to_overlappogram(cube,
     reproject_kwargs = {} if reproject_kwargs is None else reproject_kwargs
 
     if use_dask:
+        raise NotImplementedError('This currently does not work due to changes in wavelength axis.')
         import distributed
         import dask
         import dask.array

--- a/overlappy/wcs.py
+++ b/overlappy/wcs.py
@@ -70,8 +70,8 @@ def pcij_matrix(roll_angle: u.deg,
 
         P(\alpha, \gamma, \mu) &= R(\alpha - \gamma)D(\mu)R(\gamma) \\
                                &= \begin{bmatrix}
-                                    \cos{\alpha} & -\sin{\alpha} & -\mu\cos{\alpha - \gamma}\\
-                                    \sin{\alpha} & \cos{\alpha} & -\mu\sin{\alpha - \gamma}\\
+                                    \cos{(\alpha)} & -\sin{(\alpha)} & -\mu\cos{(\alpha - \gamma)}\\
+                                    \sin{(\alpha)} & \cos{(\alpha)} & -\mu\sin{(\alpha - \gamma)}\\
                                     0 & 0 & 1
                                    \end{bmatrix}
 

--- a/overlappy/wcs.py
+++ b/overlappy/wcs.py
@@ -97,8 +97,7 @@ def pcij_matrix(roll_angle: u.deg,
 
 
 @u.quantity_input
-def overlappogram_fits_wcs(detector_shape,
-                           wavelength: u.angstrom,
+def overlappogram_fits_wcs(data_shape,
                            scale,
                            reference_pixel: u.pix = None,
                            reference_coord=None,
@@ -109,11 +108,10 @@ def overlappogram_fits_wcs(detector_shape,
 
     Parameters
     ----------
-    detector_shape: `tuple`
-        Dimensions of detector (in row-major ordering)
-    wavelength: `~astropy.units.Quantity`
-        Wavelength array corresponding to the dispersion axis. This
-        must be evenly spaced.
+    data_shape: `tuple`
+        Dimensions of detector (in row-major ordering), with the leading dimension corresponding
+        to wavelength. Note that the ordering here is opposite that of the other quantities
+        which are in WCS/Cartesian-like ordering.
     scale: `tuple`
         The plate scale of the spatial and spectral directions. Each
         should be a `~astropy.units.Quantity`
@@ -132,7 +130,7 @@ def overlappogram_fits_wcs(detector_shape,
     observer: `~astropy.coordinates.SkyCoord`, optional
         Observer coordinate that defines the Helioprojective frame of the observer
         coordinate. By default will not be included. This also sets the 
-        date. 
+        date.
 
     Returns
     -------
@@ -146,8 +144,8 @@ def overlappogram_fits_wcs(detector_shape,
     # of the detector.
     if reference_pixel is None:
         reference_pixel = (
-            (detector_shape[1] - 1) / 2,
-            (detector_shape[0] - 1) / 2,
+            (data_shape[2] - 1) / 2,
+            (data_shape[1] - 1) / 2,
             0,
         ) * u.pix
     # FIXME: I don't think this is strictly correct to allow. Really, we should always
@@ -161,9 +159,9 @@ def overlappogram_fits_wcs(detector_shape,
         )
     wcs_keys = {
         'WCSAXES': 3,
-        'NAXIS1': detector_shape[1],
-        'NAXIS2': detector_shape[0],
-        'NAXIS3': wavelength.shape[0],
+        'NAXIS1': data_shape[2],
+        'NAXIS2': data_shape[1],
+        'NAXIS3': data_shape[0],
         'CDELT1': scale[0].to_value('arcsec / pix'),
         'CDELT2': scale[1].to_value('arcsec / pix'),
         'CDELT3': scale[2].to_value('angstrom / pix'),


### PR DESCRIPTION
Previously, you had to pass the full wavelength array, but this is not needed. Instead, just pass a shape with three dimensions in which the first dimension corresponds to wavelength.

Additionally, this also marks the Dask-mode of the reprojection as not implemented because we can no longer assume that the wavelength scales between the spectral cube and the detector cube are equal.